### PR TITLE
Setup pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,6 @@ repos:
   hooks:
     # Run the linter.
     - id: ruff-check
-      args: ["--select", "F,I,ERA001", "--fix"]
+      args: ["--select", "F,I", "--fix"]
     # Run the formatter.
     - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+    -   id: check-yaml
+    -   id: check-toml
+    -   id: requirements-txt-fixer
+    -   id: check-docstring-first
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.12.9
+  hooks:
+    # Run the linter.
+    - id: ruff-check
+      args: ["--select", "F,I,ERA001", "--fix"]
+    # Run the formatter.
+    - id: ruff-format

--- a/api/server.py
+++ b/api/server.py
@@ -1,12 +1,10 @@
+from dareplane_utils.default_server.server import DefaultServer
 from fire import Fire
 
-from dareplane_utils.default_server.server import DefaultServer
 from arduino_stim.main import get_main_thread
 
 
 def main(port: int = 8080, ip: str = "127.0.0.1", loglevel: int = 10):
-    # logger.setLevel(loglevel)
-
     pcommand_map = {
         "START": get_main_thread  # note: that this will return a thread and an according stop_event, the default server will be able to do the bookkeeping including stopping the thread when STOP or CLOSE are called
     }

--- a/api/server.py
+++ b/api/server.py
@@ -5,6 +5,7 @@ from arduino_stim.main import get_main_thread
 
 
 def main(port: int = 8080, ip: str = "127.0.0.1", loglevel: int = 10):
+    # logger.setLevel(loglevel)
     pcommand_map = {
         "START": get_main_thread  # note: that this will return a thread and an according stop_event, the default server will be able to do the bookkeeping including stopping the thread when STOP or CLOSE are called
     }

--- a/arduino_stim/main.py
+++ b/arduino_stim/main.py
@@ -80,6 +80,7 @@ def main(stop_event: threading.Event = threading.Event(), logger_level: int = 10
                     if val != last_val and len(val) == 1:
                         ival = int(val[0])
                         if ival > 127:
+                            # print("Pushing up-down")
                             arduino.write("u\n".encode())
                             arduino.write("d\n".encode())
 
@@ -108,7 +109,28 @@ def write_and_read(arduino: serial.Serial, message: str):
     while time.time_ns() - tpre < 10_000_000_000:
         arduino.write("u\n".encode())
         arduino.write("d\n".encode())
+    # l = arduino.readline()
+    # #
+    # tfirst = time.time_ns()
+    # print(f"{tfirst-tpre=}")
+    # l2 = arduino.readline()
+    # tsecond = time.time_ns()
+    #
+    # l = l.decode()
+    # l2 = l2.decode()
+    #
+    # retstr = f"{l=} {l2=} {tsecond-tfirst=} {tfirst-tpre=} {tsecond-tpre=}"
+    # print(retstr)
 
+
+# In [89]: %timeit arduino.write('u'.encode())
+# 520 µs ± 19.7 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops ea
+# ch)
+# Also the full cycle seems to be about 520us as tested with the oscilloscope and this:
+#
+# while time.time_ns() - tpre < 10_000_000_000:
+#     arduino.write('u'.encode())
+#     arduino.write('d'.encode())
 
 if __name__ == "__main__":
     Fire(main)

--- a/tests/lsl_stream_for_testing.py
+++ b/tests/lsl_stream_for_testing.py
@@ -1,13 +1,11 @@
-import pylsl
-
-from fire import Fire
-
 import numpy as np
-
+import pylsl
+from fire import Fire
 
 SIM_SFREQ_HZ = 100
 
 SWITCH_FREQ_HZ = 2
+
 
 def get_data(high_val: float = 150) -> np.ndarray:
     data = np.zeros(SIM_SFREQ_HZ * 6000)
@@ -16,19 +14,15 @@ def get_data(high_val: float = 150) -> np.ndarray:
 
     i = high_seq_len
     while i < len(data):
-        data[i:(i + high_seq_len)] = high_val
+        data[i : (i + high_seq_len)] = high_val
         i += 2 * high_seq_len
-        
 
     return data
 
 
 def main(stream_name="control_signal"):
     data = get_data()
-    info = pylsl.StreamInfo(
-        stream_name,
-        "EEG", 1, SIM_SFREQ_HZ, "float32", "myuidtest"
-    )
+    info = pylsl.StreamInfo(stream_name, "EEG", 1, SIM_SFREQ_HZ, "float32", "myuidtest")
     outlet = pylsl.StreamOutlet(info)
 
     # Send data
@@ -41,7 +35,7 @@ def main(stream_name="control_signal"):
         required_samples = int(SIM_SFREQ_HZ * elapsed_time) - sent_samples
         if required_samples > 0:
             stamp = pylsl.local_clock()
-            outlet.push_chunk(list(data[i: i+required_samples]), stamp)
+            outlet.push_chunk(list(data[i : i + required_samples]), stamp)
             sent_samples += required_samples
 
             i += required_samples

--- a/tests/manual_write_to_arduino.py
+++ b/tests/manual_write_to_arduino.py
@@ -1,12 +1,9 @@
-
 import time
+
 import serial
 
 dt = 0.5
-with serial.Serial(
-    port="COM3", baudrate=19200, timeout=0.1
-) as arduino:
-
+with serial.Serial(port="COM3", baudrate=19200, timeout=0.1) as arduino:
     for i in range(20):
         print(f"Loop {i}")
 
@@ -17,5 +14,3 @@ with serial.Serial(
         arduino.write("d\n".encode())
         time.sleep(dt)
         print(arduino.read(100))
-
-


### PR DESCRIPTION
Firstly, this PR introduces a [pre-commit](https://pre-commit.com/hooks.html) configuration to automatically check and fix code quality and style before commits. This should help align style across the Dareplane repo's, improving readability and removing the need to worry about formatting code yourself.

The hooks currently added are:

General checks (via pre-commit-hooks):
- check-yaml: validates YAML files
- check-toml: validates TOML files
- requirements-txt-fixer: sorts requirements.txt file
- check-docstring-first: ensures docstrings are at the right place

Python linting and formatting (via [Ruff](https://docs.astral.sh/ruff/))

- ruff-check: runs Ruff linter with
  - F → Pyflakes checks (unused variables, undefined names, etc.)
  - I → Sort imports
  - ERA001 → Check for commented-out code (not sure if necessary,  but it could be a good way to clean up the repo's and remove old commented out code. @matthiasdold what do you think?)
  - --fix to automatically apply safe fixes
- ruff-format: runs the Ruff formatter to enforce consistent style/formatting

Secondly, this PR runs the hooks on this repo, fixing all style/formatting issues. Since the rule ERA001 is currently activated, commented-out code produces errors, so these lines have also been removed.

@matthiasdold let me know what you think of adding this! If you agree, I will add this setup to the other Dareplane repo's as well.